### PR TITLE
删除MySQL容器暴露的3306端口，减小攻击面

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
       - TZ=Asia/Shanghai
       - MYSQL_DATABASE=linglong
       - MYSQL_ROOT_PASSWORD=linglong8s
-    ports:
-      - "3305:3306"
     restart: always
     command: [
       '--character-set-server=utf8mb4',


### PR DESCRIPTION
#11 
删除MySQL容器暴露的3306端口，减小攻击面
使用docker-compose启动后，app通过启动的容器名称直接连接数据库，无需将数据库端口暴露出来。